### PR TITLE
fix: replace jCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
@@ -48,7 +48,7 @@ repositories {
         url("$rootDir/../node_modules/react-native/android")
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -38,7 +38,6 @@ allprojects {
             }
         }
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
What is it?
- jCenter has been down for a while https://status.gradle.com/incidents/9740r6bzx438. jCenter is deprecated now.
- Replace jCenter with mavenCentral

Resolves https://github.com/cwhenderson20/react-native-crash-tester/issues/2